### PR TITLE
Linux includes & remove superfluous Rblas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Backup files
 *~
+
+r_test

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 
 R_BASE = /Library/Frameworks/R.framework/Resources
 
-CFLAGS = -g -I$(R_BASE)/include
-LFLAGS = -L$(R_BASE)/lib -lR -lRblas
+CFLAGS = -g -I$(R_BASE)/include -I/usr/share/R/include
+LFLAGS = -L$(R_BASE)/lib -lR
 
 r_test: r_test.c
 	$(CC) -o $@ $(CFLAGS) $(LFLAGS) $^

--- a/r_test_linux.sh
+++ b/r_test_linux.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Launch script for the call R from C example program.
+
+export R_HOME=/usr/lib/R
+export LD_LIBRARY_PATH=$R_HOME/lib
+
+./r_test


### PR DESCRIPTION
It should work under Linux and Mac at the same time.

Rblas is not needed for this example.